### PR TITLE
fix: `Used in` column sortable

### DIFF
--- a/ui/components/RegexTable.vue
+++ b/ui/components/RegexTable.vue
@@ -109,7 +109,7 @@ const currentRegex = shallowRef<RegexInfo | null>(null)
       </template>
     </Column>
 
-    <Column field="files" header="Used in" sortable header-class="pr-4">
+    <Column field="filesCalled.length" header="Used in" sortable header-class="pr-4">
       <template #body="{ data }">
         <div flex="~ gap-1 items-center justify-end">
           <Dropdown>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently the `Used in` column sort action invalid. Replace the `field` name to fixed it.
