### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prepare": "simple-git-hooks"
   },
   "dependencies": {
+    "ansis": "^3.12.0",
     "cac": "^6.7.14",
     "error-stack-parser-es": "^0.1.4",
     "exit-hook": "^4.0.0",
@@ -65,7 +66,6 @@
     "launch-editor": "^2.6.1",
     "mrmime": "^2.0.0",
     "open": "^10.1.0",
-    "picocolors": "^1.0.1",
     "trace-record": "^0.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      ansis:
+        specifier: ^3.12.0
+        version: 3.12.0
       cac:
         specifier: ^6.7.14
         version: 6.7.14
@@ -35,9 +38,6 @@ importers:
       open:
         specifier: ^10.1.0
         version: 10.1.0
-      picocolors:
-        specifier: ^1.0.1
-        version: 1.0.1
       trace-record:
         specifier: ^0.2.0
         version: 0.2.0
@@ -2144,6 +2144,10 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  ansis@3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
+
   anymatch@2.0.0:
     resolution: {integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==}
 
@@ -2435,7 +2439,6 @@ packages:
 
   chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
-    deprecated: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2602,6 +2605,7 @@ packages:
 
   copy-concurrently@1.0.5:
     resolution: {integrity: sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==}
+    deprecated: This package is no longer supported.
 
   copy-descriptor@0.1.1:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
@@ -3435,6 +3439,7 @@ packages:
 
   fs-write-stream-atomic@1.0.10:
     resolution: {integrity: sha512-gehEzmPn2nAwr39eay+x3X34Ra+M2QlVUTLhkXPjWdeO8RF9kszk116avgBJM3ZyNHgHXBNx+VmPaFC36k0PzA==}
+    deprecated: This package is no longer supported.
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -3443,7 +3448,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4396,6 +4401,7 @@ packages:
 
   move-concurrently@1.0.1:
     resolution: {integrity: sha512-hdrFxZOycD/g6A6SoI2bB5NA/5NEqD0569+S47WZhPvm46sD50ZHdYaFmnua5lndde9rCHGjmfK7Z8BuCt/PcQ==}
+    deprecated: This package is no longer supported.
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -5435,6 +5441,7 @@ packages:
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
@@ -9160,6 +9167,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
+
+  ansis@3.12.0: {}
 
   anymatch@2.0.0:
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,11 +4,11 @@ import { resolve } from 'node:path'
 import open from 'open'
 import { getPort } from 'get-port-please'
 import cac from 'cac'
-import c from 'picocolors'
+import { blue, green } from 'ansis'
 import { createHostServer } from './server'
 
-// const MARK_CHECK = c.green('✔')
-const MARK_INFO = c.blue('ℹ')
+// const MARK_CHECK = green('✔')
+const MARK_INFO = blue('ℹ')
 
 const cli = cac('regex-doctor')
 
@@ -26,7 +26,7 @@ cli
     if (process.env.ESLINT_CONFIG)
       options.config ||= process.env.ESLINT_CONFIG
 
-    console.log(MARK_INFO, `Starting RegexDoctor viewer at`, c.green(`http://${host}:${port}`), '\n')
+    console.log(MARK_INFO, `Starting RegexDoctor viewer at`, green`http://${host}:${port}`, '\n')
 
     const cwd = process.cwd()
     const server = await createHostServer({

--- a/src/register.ts
+++ b/src/register.ts
@@ -2,7 +2,7 @@
 import fs from 'node:fs'
 import process from 'node:process'
 import exitHook from 'exit-hook'
-import c from 'picocolors'
+import { blue, green } from 'ansis'
 import { RegexDoctor } from './doctor'
 
 console.log(`[regex-doctor] start tracking`)
@@ -17,5 +17,5 @@ exitHook(() => {
   fs.writeFileSync('./.regex-doctor/output.json', JSON.stringify(doctor.dump({
     cwd,
   }), null, 2))
-  console.log(`[regex-doctor] output saved to ${c.blue('./.regex-doctor/output.json')}, run ${c.green(c.bold('npx regex-doctor view'))} to view it in an interactive UI.`)
+  console.log(`[regex-doctor] output saved to ${blue`./.regex-doctor/output.json`}, run ${green.bold`npx regex-doctor view`} to view it in an interactive UI.`)
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hello @antfu,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.
Ansis is nearly as small (6.8 kB) as Picocolors (6.4 kB).

