### PR TITLE
fix: error ui baseURL config

### DIFF
--- a/ui/nuxt.config.ts
+++ b/ui/nuxt.config.ts
@@ -57,7 +57,7 @@ export default defineNuxtConfig({
   },
 
   app: {
-    baseURL: './',
+    baseURL: '/',
     head: {
       viewport: 'width=device-width,initial-scale=1',
       link: [


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In the previous regex-doctor\ui\nuxt.config.ts, app.baseURL was configured as './', so the link in the terminal was displayed as http://localhost:3000./, so I changed './' to '/' so that the link could be opened normally.

### Linked Issues


### Additional context

![wechat_2025-03-08_233547_010](https://github.com/user-attachments/assets/63a7139f-18df-484a-b528-9a832ec632fc)
![image](https://github.com/user-attachments/assets/22d0e17a-51d3-4e61-b5e7-ef26c61555ca)

